### PR TITLE
Rename to Web: update repository name in tests and staging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 workspace:
   base: /go
-  path: src/github.com/src-d/gitbase-playground
+  path: src/github.com/src-d/gitbase-web
 
 branches: [master]
 

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -36,8 +36,8 @@ gitbaseServer:
       #commit: v4.4.0
     gitbase:
       url: https://github.com/src-d/gitbase.git
-    gitbase-playground:
-      url: https://github.com/src-d/gitbase-playground.git
+    gitbase-web:
+      url: https://github.com/src-d/gitbase-web.git
     bblfshd:
       url: https://github.com/bblfsh/bblfshd.git
     siva-java:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       - docker exec -it bblfshd bblfshctl driver install go docker://bblfsh/go-driver:latest
       - docker exec -it bblfshd bblfshctl driver install javascript docker://bblfsh/javascript-driver:latest
       - mkdir $HOME/repos
-      - git clone https://github.com/src-d/gitbase-playground.git $HOME/repos/gitbase-playground
+      - git clone https://github.com/src-d/gitbase-web.git $HOME/repos/gitbase-web
       - docker run -d --name gitbase -p "3367:3306" -e "BBLFSH_ENDPOINT=bblfshd:9432" --volume $HOME/repos:/opt/repos --link bblfshd srcd/gitbase
       - sleep 15
       - GITBASEPG_DB_CONNECTION='root@tcp(localhost:3367)/none' GITBASEPG_INTEGRATION_TESTS=true make test

--- a/server/handler/export_integration_test.go
+++ b/server/handler/export_integration_test.go
@@ -50,13 +50,13 @@ func (suite *ExportIntegrationSuite) TestSuccess() {
 	r := csv.NewReader(res.Body)
 
 	record, err := r.Read()
-	suite.Nil(err)
-	suite.Equal(record, []string{"repository_id"})
+	suite.Require().Nil(err)
+	suite.Require().Equal(record, []string{"repository_id"})
 
 	record, err = r.Read()
-	suite.Nil(err)
-	suite.Equal(len(record), 1)
-	suite.True(len(record[0]) > 0)
+	suite.Require().Nil(err)
+	suite.Require().Equal(len(record), 1)
+	suite.Require().True(len(record[0]) > 0)
 }
 
 func (suite *ExportIntegrationSuite) TestError() {


### PR DESCRIPTION
Part of #218.

Changes the repository name for drone, travis, and staging.