### PR TITLE
quickstart.md: remove bogus instruction

### DIFF
--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -31,7 +31,6 @@ Everytime you want to add a new repository to gitbase, the application should be
 Run the [latest released version of the frontend](https://hub.docker.com/r/srcd/gitbase-playground/tags/):
 
 ```bash
-$ docker-compose pull --include-deps playground
 $ GITBASEPG_REPOS_FOLDER=./repos docker-compose up --force-recreate
 ```
 


### PR DESCRIPTION
The "playground" service does not exist in docker-compose.yml, so the instruction to pull it was failing. In addition, it seems that 'docker-compose up' automatically pulls all the necessary images anyway, so there's no need to 'docker-compose pull' anything beforehand.
