### PR TITLE
Update staging to gitbase 0.16.0

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -1,32 +1,32 @@
 bblfshdServer:
   image:
     repository: bblfsh/bblfshd
-    tag: v2.5.0
+    tag: v2.6.1
     pullPolicy: IfNotPresent
   drivers:
     install: true
     languages:
       python:
         repository: bblfsh/python-driver
-        tag: v2.0.0
+        tag: v2.3.0
       java:
         repository: bblfsh/java-driver
-        tag: v1.2.6
+        tag: v2.2.0
       php:
         repository: bblfsh/php-driver
-        tag: v2.0.0
+        tag: v2.3.0
       ruby:
         repository: bblfsh/ruby-driver
-        tag: v2.0.0
+        tag: v2.3.0
       javascript:
         repository: bblfsh/javascript-driver
-        tag: v1.2.0
+        tag: v2.2.0
       bash:
         repository: bblfsh/bash-driver
         tag: v1.1.1
       go:
         repository: bblfsh/go-driver
-        tag: v0.4.0
+        tag: v2.2.0
 
 gitbaseServer:
   # commit defaults to HEAD unless given
@@ -44,7 +44,7 @@ gitbaseServer:
       url: https://github.com/src-d/siva-java.git
   image:
     repository: srcd/gitbase
-    tag: v0.15.0
+    tag: v0.16.0
     pullPolicy: IfNotPresent
   squashEnable: "true"
   readonly: "true"


### PR DESCRIPTION
I changed the bblfsh and drivers versions to latest because we were trying to avoid any of the v2 changes, but this is not necessary anymore.