### PR TITLE
Use fixed versions in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,14 @@ services:
     depends_on:
       - gitbase
   gitbase:
-    image: "srcd/gitbase"
+    image: "srcd/gitbase:v0.16.0"
     environment:
       BBLFSH_ENDPOINT: bblfsh:9432
       GITBASE_UNSTABLE_SQUASH_ENABLE: "true"
     volumes:
       - ${GITBASEPG_REPOS_FOLDER}:/opt/repos
   bblfsh:
-    image: "bblfsh/bblfshd"
+    image: "bblfsh/bblfshd:v2.7.2"
     privileged: true
     volumes:
       - type: volume


### PR DESCRIPTION
Gitbase `latest` tag points to a RC, and bblfsh 2.8.0 exits when you try to install a language that is already installed.
Now that gitbase-web is stable, let's play it safe and set fixed versions!