### PR TITLE
Update to bblfsh 2.9, use -drivers image

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -1,7 +1,7 @@
 bblfshdServer:
   image:
     repository: bblfsh/bblfshd
-    tag: v2.7.0
+    tag: v2.9.0
     pullPolicy: IfNotPresent
   drivers:
     install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,10 @@ jobs:
         - make coverage
         - make validate-commit
     - script:
-      # TODO (carlosms) fixed bblfshd version because latest fails with https://github.com/bblfsh/bblfshd/issues/195
-      - docker run -d --name bblfshd --privileged --volume $HOME/bblfsh-drivers:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd:v2.7.2
+      - docker run -d --name bblfshd --privileged --volume $HOME/bblfsh-drivers:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
       - sleep 5
-      - docker exec -it bblfshd bblfshctl driver install go docker://bblfsh/go-driver:latest
-      - docker exec -it bblfshd bblfshctl driver install javascript docker://bblfsh/javascript-driver:latest
+      - docker exec -it bblfshd bblfshctl driver install --force go docker://bblfsh/go-driver:latest
+      - docker exec -it bblfshd bblfshctl driver install --force javascript docker://bblfsh/javascript-driver:latest
       - mkdir $HOME/repos
       - git clone https://github.com/src-d/gitbase-web.git $HOME/repos/gitbase-web
       - docker run -d --name gitbase -p "3367:3306" -e "BBLFSH_ENDPOINT=bblfshd:9432" --volume $HOME/repos:/opt/repos --link bblfshd srcd/gitbase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,16 +19,5 @@ services:
     volumes:
       - ${GITBASEPG_REPOS_FOLDER}:/opt/repos
   bblfsh:
-    image: "bblfsh/bblfshd:v2.7.2"
+    image: "bblfsh/bblfshd:v2.9.0-drivers"
     privileged: true
-    volumes:
-      - type: volume
-        source: drivers
-        target: /var/lib/bblfshd
-    entrypoint: ["/bin/sh"]
-    command:
-    - "-c"
-    - "bblfshd & sleep 5 && bblfshctl driver install --recommended && tail -f /dev/null"
-
-volumes:
-  drivers:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,16 +18,14 @@ Make sure you also satisfy these requirements:
 
 As with a normal deployment, if you don't use Docker Compose you will need to configure a [gitbase](https://docs.sourced.tech/gitbase) server, and a [bblfsh](https://doc.bblf.sh/) server. It is recommended to read their documentation, but here is a quick guide on how to run both as docker containers.
 
-Launch bblfshd and install the required drivers:
+Launch bblfshd. The `-drivers` image already contains all the recommended drivers:
 
 ```bash
 $ docker run \
     --privileged \
     --publish 9432:9432 \
-    --volume /var/lib/bblfshd:/var/lib/bblfshd \
     --name bblfsh \
-    bblfsh/bblfshd
-$ docker exec -it bblfsh bblfshctl driver install --recommended
+    bblfsh/bblfshd:latest-drivers
 ```
 
 gitbase will serve Git repositories, so you will need to to populate a directory with them:


### PR DESCRIPTION
- Use bblfsh `-drivers` image in `docker-compose` and dev. docs.
- Bring back the `latest` bblfshd to travis to detect problems with new releases.
- Update staging to 2.9.0

