### PR TITLE
[HOTFIX] Set DB conn reuse timeout

### DIFF
--- a/cmd/gitbase-web/main.go
+++ b/cmd/gitbase-web/main.go
@@ -51,6 +51,8 @@ func (c *ServeCommand) Execute(args []string) error {
 	}
 	defer db.Close()
 
+	db.SetMaxIdleConns(0)
+
 	static := handler.NewStatic("build/public", c.ServerURL, c.SelectLimit, c.FooterHTML)
 
 	// start the router


### PR DESCRIPTION
After an idle time of >60s the next query was always failing with `Query Failed - invalid connection`.
Apparently the problem is that the connection was close on gitbase's end and we still kept it open on our side.

More context in this thread:
https://github.com/go-sql-driver/mysql/issues/674#issuecomment-345661869