### PR TITLE
Disable cancel button for older browsers

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -198,7 +198,9 @@ FROM ( SELECT MONTH(committer_when) as month,
 
   loadQuery(key, sql) {
     const { history } = this.state;
-    const abortController = new window.AbortController();
+    const abortController = window.AbortController
+      ? new window.AbortController()
+      : undefined;
 
     const loadingResults = new Map(this.state.results);
     loadingResults.set(key, { sql, loading: true, abortController });
@@ -220,8 +222,9 @@ FROM ( SELECT MONTH(committer_when) as month,
       () => this.handleSetActiveResult(key)
     );
 
+    const signal = abortController ? abortController.signal : undefined;
     api
-      .query(sql, abortController.signal)
+      .query(sql, signal)
       .then(response => {
         this.setResult(key, { sql, response });
 

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -210,6 +210,8 @@ class TabbedResults extends Component {
     const { codeModalShow, codeModalContent } = this.state;
     const { showUAST, history, languages } = this.props;
 
+    const cancelDisabled = window.AbortController === undefined;
+
     return (
       <div className="results-padding full-height full-width">
         <DivTabs
@@ -242,6 +244,7 @@ class TabbedResults extends Component {
                         <Button
                           className="animation-action cancel"
                           bsStyle="gbpl-tertiary"
+                          disabled={cancelDisabled}
                           onClick={() => this.props.handleAbortQuery(key)}
                         >
                           CANCEL

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import 'bootstrap/dist/css/bootstrap.css';
 import './variables.less';
 import App from './App';
 
 ReactDOM.render(<App />, document.getElementById('root'));
+
+if (!window.AbortController) {
+  // eslint-disable-next-line no-console
+  console.warn(`Cancelling gitbase queries is disabled; your browser does not support the AbortController interface.
+Please check for compatibility here: https://developer.mozilla.org/en-US/docs/Web/API/AbortController#Browser_compatibility`);
+}


### PR DESCRIPTION
Fix #265.

With this change the cancel button is grayed out, and if you go to the console you'll see the reason and a link to the supported browser versions.