### PR TITLE
Update go-cli dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -370,12 +370,11 @@
   version = "v1.6.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e94a01f8f9d83588646b3d3f34c83fef13969d6bcdd36439328601d1fe15c155"
+  digest = "1:5b120881c392f818b3427e8b3788da19bf6db136b497f4c1bd253932f415fe15"
   name = "gopkg.in/src-d/go-cli.v0"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "af27c1c1917553e2b9fd8fb7c822345df6615d34"
+  revision = "b67fb56aacf6ab362e2758a584eb346816a18ff8"
 
 [[projects]]
   digest = "1:e79c76b3315c08c2c9d4d09d308ef2be7e4a4161fdcbe5c56040b3641f21096c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,3 +53,7 @@
 [[constraint]]
   name = "gopkg.in/src-d/enry.v1"
   version = "1.6.4"
+
+[[constraint]]
+  name = "gopkg.in/src-d/go-cli.v0"
+  revision = "b67fb56aacf6ab362e2758a584eb346816a18ff8"

--- a/vendor/gopkg.in/src-d/go-cli.v0/log.go
+++ b/vendor/gopkg.in/src-d/go-cli.v0/log.go
@@ -7,8 +7,8 @@ import (
 // LogOptions defines logging flags. It is meant to be embedded in a
 // command struct.
 type LogOptions struct {
-	LogLevel       string `long:"log-level" env:"LOG_LEVEL" default:"info" description:"Logging level (info, debug, warning or error)"`
-	LogFormat      string `long:"log-format" env:"LOG_FORMAT" description:"log format (text or json), defaults to text on a terminal and json otherwise"`
+	LogLevel       string `long:"log-level" env:"LOG_LEVEL" choice:"info" choice:"debug" choice:"warning" choice:"error" default:"info" description:"Logging level"`
+	LogFormat      string `long:"log-format" env:"LOG_FORMAT" choice:"text" choice:"json" description:"log format, defaults to text on a terminal and json otherwise"`
 	LogFields      string `long:"log-fields" env:"LOG_FIELDS" description:"default fields for the logger, specified in json"`
 	LogForceFormat bool   `long:"log-force-format" env:"LOG_FORCE_FORMAT" description:"ignore if it is running on a terminal or not"`
 }


### PR DESCRIPTION
Update to make use of `choice` in log options, https://github.com/src-d/go-cli/pull/9.

Before:
```
Usage:
  gitbase-web [OPTIONS] serve [serve-OPTIONS]

starts serving the application

Help Options:
  -h, --help                  Show this help message

[serve command options]
          --host=             IP address to bind the HTTP server (default: 0.0.0.0) [$GITBASEPG_HOST]
          --port=             Port to bind the HTTP server (default: 8080) [$GITBASEPG_PORT]
          --server=           URL used to access the application in the form 'HOSTNAME[:PORT]'. Leave it unset to allow connections from
                              any proxy or public address [$GITBASEPG_SERVER_URL]
          --db=               gitbase connection string. Use the DSN (Data Source Name) format described in the Go MySQL Driver docs:
                              https://github.com/go-sql-driver/mysql#dsn-data-source-name (default:
                              root@tcp(localhost:3306)/none?maxAllowedPacket=4194304) [$GITBASEPG_DB_CONNECTION]
          --select-limit=     Default 'LIMIT' forced on all the SQL queries done from the UI. Set it to 0 to remove any limit (default:
                              100) [$GITBASEPG_SELECT_LIMIT]
          --bblfsh=           Address where bblfsh server is listening (default: 127.0.0.1:9432) [$GITBASEPG_BBLFSH_SERVER_URL]
          --footer=           Allows to add any custom html to the page footer. It must be a string encoded in base64. Use it, for
                              example, to add your analytics tracking code snippet [$GITBASEPG_FOOTER_HTML]

    Log Options:
          --log-level=        Logging level (info, debug, warning or error) (default: info) [$LOG_LEVEL]
          --log-format=       log format (text or json), defaults to text on a terminal and json otherwise [$LOG_FORMAT]
          --log-fields=       default fields for the logger, specified in json [$LOG_FIELDS]
          --log-force-format  ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
```

After
```
Usage:
  gitbase-web [OPTIONS] serve [serve-OPTIONS]

starts serving the application

Help Options:
  -h, --help                                     Show this help message

[serve command options]
          --host=                                IP address to bind the HTTP server (default: 0.0.0.0) [$GITBASEPG_HOST]
          --port=                                Port to bind the HTTP server (default: 8080) [$GITBASEPG_PORT]
          --server=                              URL used to access the application in the form 'HOSTNAME[:PORT]'. Leave it unset to
                                                 allow connections from any proxy or public address [$GITBASEPG_SERVER_URL]
          --db=                                  gitbase connection string. Use the DSN (Data Source Name) format described in the Go
                                                 MySQL Driver docs: https://github.com/go-sql-driver/mysql#dsn-data-source-name (default:
                                                 root@tcp(localhost:3306)/none?maxAllowedPacket=4194304) [$GITBASEPG_DB_CONNECTION]
          --select-limit=                        Default 'LIMIT' forced on all the SQL queries done from the UI. Set it to 0 to remove
                                                 any limit (default: 100) [$GITBASEPG_SELECT_LIMIT]
          --bblfsh=                              Address where bblfsh server is listening (default: 127.0.0.1:9432)
                                                 [$GITBASEPG_BBLFSH_SERVER_URL]
          --footer=                              Allows to add any custom html to the page footer. It must be a string encoded in base64.
                                                 Use it, for example, to add your analytics tracking code snippet [$GITBASEPG_FOOTER_HTML]

    Log Options:
          --log-level=[info|debug|warning|error] Logging level (default: info) [$LOG_LEVEL]
          --log-format=[text|json]               log format, defaults to text on a terminal and json otherwise [$LOG_FORMAT]
          --log-fields=                          default fields for the logger, specified in json [$LOG_FIELDS]
          --log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
```