### PR TITLE
Update dockerfile dependencies for bblfsh client-go v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:stretch-slim
 RUN apt-get update && \
   apt-get install -y --no-install-recommends --no-install-suggests \
   ca-certificates \
-  libxml2 \
   && apt-get clean
 
 ADD ./build/bin /bin


### PR DESCRIPTION
Part of #248.
Updates the dockerfile to remove packages not needed after bblfsh/client-go was updated to v3.