### PR TITLE
Service defaults have changed in upstream chart

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,7 @@ helm_deploy: &helm_deploy
   skip_tls_verify: true
   helm_repos: srcd-charts=https://src-d.github.io/charts/
   chart: srcd-charts/gitbase-web
+  chart-version: 0.2.1
   release: gp
   tiller_ns: kube-system
   wait: true

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -1,3 +1,7 @@
+service:
+  type: NodePort
+  port: 8080
+
 bblfshdServer:
   image:
     repository: bblfsh/bblfshd


### PR DESCRIPTION
Hence we fix the old defaults to avoid changes in our deployment. The
main thing is to fix service type to node port as it is required by GCE
ingress.

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>