### PR TITLE
Fix panic for malformed UAST unmarshal

### DIFF
--- a/server/service/uast.go
+++ b/server/service/uast.go
@@ -69,6 +69,10 @@ func UnmarshalUAST(data []byte) ([]*Node, error) {
 			return nil, ErrUnmarshalUAST.New(err)
 		}
 
+		if nodeLen < 1 {
+			return nil, ErrUnmarshalUAST.New(fmt.Errorf("malformed data"))
+		}
+
 		node := uast.NewNode()
 		nodeBytes := buf.Next(int(nodeLen))
 		if int32(len(nodeBytes)) != nodeLen {

--- a/server/service/uast_test.go
+++ b/server/service/uast_test.go
@@ -1,0 +1,31 @@
+package service_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/src-d/gitbase-web/server/service"
+	"github.com/stretchr/testify/suite"
+)
+
+type UastSuite struct {
+	suite.Suite
+}
+
+func TestUastSuite(t *testing.T) {
+	s := new(UastSuite)
+	suite.Run(t, s)
+}
+
+func (suite *UastSuite) TestNegativeNodeLen() {
+	var nodeLen int32 = -20
+
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.BigEndian, nodeLen)
+	suite.Require().NoError(err)
+
+	nodes, err := service.UnmarshalUAST(buf.Bytes())
+	suite.Require().Error(err)
+	suite.Require().Nil(nodes)
+}


### PR DESCRIPTION
Fix #288.

Because we try to unmarshal any string to see if it's UAST, we can get to a situation where `nodeLen` is negative, which breaks the buffer offset in `buf.Next`.