### PR TITLE
Update to bblfshd 2.10.0

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -5,32 +5,35 @@ service:
 bblfshdServer:
   image:
     repository: bblfsh/bblfshd
-    tag: v2.9.0
+    tag: v2.10.0
     pullPolicy: IfNotPresent
   drivers:
     install: true
     languages:
       python:
         repository: bblfsh/python-driver
-        tag: v2.3.0
+        tag: v2.4.0
+      cpp:
+        repository: bblfsh/cpp-driver
+        tag: v0.3.0
       java:
         repository: bblfsh/java-driver
-        tag: v2.2.0
+        tag: v2.3.0
       php:
         repository: bblfsh/php-driver
-        tag: v2.3.0
+        tag: v2.4.0
       ruby:
         repository: bblfsh/ruby-driver
-        tag: v2.3.0
+        tag: v2.4.0
       javascript:
         repository: bblfsh/javascript-driver
-        tag: v2.2.0
+        tag: v2.3.0
       bash:
         repository: bblfsh/bash-driver
-        tag: v1.1.1
+        tag: v2.1.0
       go:
         repository: bblfsh/go-driver
-        tag: v2.2.0
+        tag: v2.3.0
 
 gitbaseServer:
   # commit defaults to HEAD unless given

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,5 @@ services:
     volumes:
       - ${GITBASEPG_REPOS_FOLDER}:/opt/repos
   bblfsh:
-    image: "bblfsh/bblfshd:v2.9.0-drivers"
+    image: "bblfsh/bblfshd:v2.10.0-drivers"
     privileged: true


### PR DESCRIPTION
Update bblfsh to 2.10.0 in docker compose and staging deployment. For staging I also updated the drivers to the versions included in the `v2.10.0-drivers` docker image.