### PR TITLE
Added antiaffinity rules

### DIFF
--- a/.helm-defaults.yml
+++ b/.helm-defaults.yml
@@ -58,3 +58,15 @@ gitbaseServer:
 
 nodeSelector:
   cloud.google.com/gke-nodepool: default-pool
+
+affinity:
+   podAntiAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+     - labelSelector:
+        matchExpressions:
+         - key: app
+           operator: In
+           values:
+        #if the chart name is changed or a nameOverride is used, this value has to be changed to the new name.
+           - gitbase-web
+       topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Antiaffinity rules to avoid two or more pods running on the same node.

Signed-off-by: David Riosalido <driosalido@sourced.tech>