### PR TITLE
Set help link target to blank

### DIFF
--- a/frontend/src/components/HelpModal.js
+++ b/frontend/src/components/HelpModal.js
@@ -20,7 +20,11 @@ class HelpModal extends Component {
           <div>
             For a reference of gitbase SQL, please read{' '}
             <strong>
-              <a href="https://docs.sourced.tech/gitbase">
+              <a
+                href="https://docs.sourced.tech/gitbase"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 docs.sourced.tech/gitbase
               </a>
             </strong>


### PR DESCRIPTION
The link made in #298 should have had the same `target` as the ones in the sidebar.