### PR TITLE
Limit travis builds to master and release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 language: go
 
 services:


### PR DESCRIPTION
Related to #311.

The dependabot branches are creating too many duplicated travis builds for both the PR and the branch, this PR limits the builds to master and release tags.