### PR TITLE
Update docker-compose.yml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ git clone git@github.com:bblfsh/bblfshd.git
 $ git clone git@github.com:src-d/gitbase-web.git
 ```
 
-Next you will need to download the `docker-compose.yml` file from this repository and run `docker-compose`. This tool will run three different containers: the gitbase-web frontend itself, gitbase, and bblfshd. To kill the running containers use `Ctrl+C`.
+Next you will need to download the `docker-compose.yml` file from this repository and run `docker-compose up`. This tool will run three different containers: the gitbase-web frontend itself, gitbase, and bblfshd. To kill the running containers use `Ctrl+C`.
 
 ```bash
 $ wget https://raw.githubusercontent.com/src-d/gitbase-web/master/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     image: "srcd/gitbase:v0.18.0"
     environment:
       BBLFSH_ENDPOINT: bblfsh:9432
-      GITBASE_UNSTABLE_SQUASH_ENABLE: "true"
     volumes:
       - ${GITBASEPG_REPOS_FOLDER}:/opt/repos
   bblfsh:


### PR DESCRIPTION
Related to the empathy-session.

- README: fix `docker-compose up` command description.
- docker-compose.yml: remove `GITBASE_UNSTABLE_SQUASH_ENABLE: "true"` line. This is the default behavior since gitbase v0.14.0. Make the directory `./repos` the default one if there's no one set.