### PR TITLE
Fixes initialization of `UASTViewer`

### DIFF
--- a/frontend/src/components/UASTViewer.js
+++ b/frontend/src/components/UASTViewer.js
@@ -16,7 +16,7 @@ class UASTViewer extends Component {
 
     this.state = {
       loading: false,
-      flatUast: this.transform(props.uast),
+      initialFlatUast: this.transform(props.uast),
       showLocations: false,
       filter: '',
       error: null
@@ -65,9 +65,9 @@ class UASTViewer extends Component {
   }
 
   render() {
-    const { flatUast, error, loading } = this.state;
+    const { initialFlatUast, error, loading } = this.state;
     const { showLocations, filter } = this.state;
-    const uastViewerProps = { flatUast };
+    const uastViewerProps = { initialFlatUast };
 
     return (
       <div className="pg-uast-viewer">

--- a/frontend/src/components/UASTViewerPane.js
+++ b/frontend/src/components/UASTViewerPane.js
@@ -41,10 +41,11 @@ function UASTViewerPane({
 }) {
   let content = null;
 
+  const uast = uastViewerProps.flatUast || uastViewerProps.initialFlatUast;
   if (loading) {
     content = <div>loading...</div>;
-  } else if (uastViewerProps.flatUast) {
-    const searchResults = getSearchResults(uastViewerProps.flatUast);
+  } else if (uast) {
+    const searchResults = getSearchResults(uast);
     const rootIds = searchResults || [ROOT_ID];
 
     if (searchResults && !searchResults.length) {


### PR DESCRIPTION
Closes #402.

There are two problems:
1. `UASTViewerPane` checks only for `flatUast` and not
`initialFlatUast`. This means that it can work only when the
`uast-viewer` is used in *controlled mode*. This has been fixed by
checking `flatUast` first and then fallback to `initialFlatUast`.
2. `UASTViewer` component needs to be in *uncontrolled mode*, so it
needs to use `initialFlatUast`. This has ben fixed by renaming
`flatUast` into `initialFlatUast`.